### PR TITLE
modifications for more general use

### DIFF
--- a/presidential-speeches/config.yml
+++ b/presidential-speeches/config.yml
@@ -1,0 +1,7 @@
+# Presidential Speeches Configuration
+BASE_URL:       http://www.presidency.ucsb.edu/ws/index.php
+BASE_URL_PRINT: http://www.presidency.ucsb.edu/ws/print.php
+BASE_DIR:       speeches
+BEGIN_DATE:     1996-01-01
+END_DATE:       1996-12-31
+LEADER_FILTER:  ['William J. Clinton']

--- a/presidential-speeches/config.yml
+++ b/presidential-speeches/config.yml
@@ -1,7 +1,62 @@
 # Presidential Speeches Configuration
 BASE_URL:       http://www.presidency.ucsb.edu/ws/index.php
 BASE_URL_PRINT: http://www.presidency.ucsb.edu/ws/print.php
+
+# Directory to store the resulting files
 BASE_DIR:       speeches
-BEGIN_DATE:     1996-01-01
-END_DATE:       1996-12-31
-LEADER_FILTER:  ['William J. Clinton']
+
+# Begin and end dates to search, in form YYYY-MM-DD
+BEGIN_DATE:     2000-01-01
+END_DATE:       2016-12-31
+
+# Filter by Leader(s): names must match the forms in the list below exactly
+LEADER_FILTER:  []
+
+# Limit by number of presidency (single presidency only)
+PRESIDENCY: 43
+
+ALL_PRESIDENTS:
+    1: 'George Washington'
+    2: 'John Adams'
+    3: 'Thomas Jefferson'
+    4: 'James Madison'
+    5: 'James Monroe'
+    6: 'John Quincy Adams'
+    7: 'Andrew Jackson'
+    8: 'Martin van Buren'
+    9: 'William Henry Harrison'
+    10: 'John Tyler'
+    11: 'James K. Polk'
+    12: 'Zachary Taylor'
+    13: 'Millard Fillmore'
+    14: 'Franklin Pierce'
+    15: 'James Buchanan'
+    16: 'Abraham Lincoln'
+    17: 'Andrew Johnson'
+    18: 'Ulysses S. Grant'
+    19: 'Rutherford B Hayes'
+    20: 'James A. Garfield'
+    21: 'Chester A. Arthur'
+    22: 'Grover Cleveland'
+    23: 'Benjamin Harrison'
+    24: 'Grover Cleveland'
+    25: 'William McKinley'
+    26: 'Theodore Roosevelt'
+    27: 'William Howard Taft'
+    28: 'Woodrow Wilson'
+    29: 'Warren G. Harding'
+    30: 'Calvin Coolidge'
+    31: 'Herbert Hoover'
+    32: 'Franklin D. Roosevelt'
+    33: 'Harry S. Truman'
+    34: 'Dwight D. Eisenhower'
+    35: 'John F. Kennedy'
+    36: 'Lyndon B. Johnson'
+    37: 'Richard Nixon'
+    38: 'Gerald R. Ford'
+    39: 'Jimmy Carter'
+    40: 'Ronald Reagan'
+    41: 'George Bush'
+    42: 'William J. Clinton'
+    43: 'George W. Bush'
+    44: 'Barack Obama'

--- a/presidential-speeches/presidential-speeches.py
+++ b/presidential-speeches/presidential-speeches.py
@@ -25,12 +25,16 @@ def main():
     
     if not os.path.isdir(BASE_DIR):
         os.mkdir(BASE_DIR)
-
+        
+    if PRESIDENCY is not None:
+        pres = PRESIDENCY
+        
     # Open output CSV file, named with the query used
     csvFileName = os.path.join(BASE_DIR, query.replace(' ','_') + '.csv')    
     with open(csvFileName, 'w') as csvFile:
         csvWriter = csv.writer(csvFile, quoting=csv.QUOTE_ALL)
-        csvWriter.writerow(['PID','file name', 'date', 'leader', 'Speech', 'URL', 'Date (YYYMMDD)','Speech Number','Speech Unique ID'])
+        csvWriter.writerow(['PID','file name','date','leader','Speech','URL',
+            'Date (YYYMMDD)','Speech Number','Speech Unique ID'])
 
         # Execute the search using supplied query string, once per year
         for year in range(BEGIN_DATE.year, END_DATE.year + 1):
@@ -45,7 +49,8 @@ def main():
                                              'daystart' : daystart,
                                              'yearend' : str(year),
                                              'monthend' : monthend,
-                                             'dayend' : dayend
+                                             'dayend' : dayend,
+                                             'pres' : pres
             })
             
             url = BASE_URL + "?" + params
@@ -64,10 +69,12 @@ def main():
                     # data cleanup
                     leader = leader.replace('&nbsp;','').strip()
                     
-                    # cut processing loop short for rows not in leader filter
-                    if leader not in LEADER_FILTER:
-                        print("Skipping speech by {0}...".format(leader))
-                        continue
+                    # if leader filter is set, cut processing loop short for 
+                    # results not matching names in leader filter list
+                    if len(LEADER_FILTER) > 0:
+                        if leader not in LEADER_FILTER:
+                            print("Skipping speech by {0}...".format(leader))
+                            continue
                     
                     speech = speech.replace('&nbsp;','')
                     speech = re.sub(r'<.*?>', '', speech)


### PR DESCRIPTION
In the process of tweaking this code to support the downloading of all of Bush 43's and Obama 44's speeches, we have implemented the following changes to make the script more configurable:

1. moved all user-modifiable variables to a configuration file (config.yml).
2. implemented full date range searching via configuration (removing hard-coded handling of 1933).
3. added feature to filter speeches in a given range by the name of the person delivering the speech (LEADER_FILTER, n.b.: the names must match exactly the form of the "leader" field extracted from the search results list). This filter can accept multiple speakers.
4. added feature for capturing all speeches by a single given president via the "pres" query parameter (which takes the sequential number of the presidency).  This parameter can only accept a single presidency in a given query.
5. to facilitate future configuration of #3-4 above, added full list of presidents to the configuration file; originally added this list as a comment, but later changed it to be read in as an array for the future refactoring of the query string generation algorithm (this refactoring, however, has not been implemented at this time).

In implementing the above changes, we have taken care not to break the "query by keywords" feature of the previous version.  Because the immediate use-case does not need keyword searching, rather than running the script by a shell wrapper, the python script should be run directly, with either nothing or an empty string passed as the first argument.